### PR TITLE
Add additional option --no-snapshots to prevent zypper migration from

### DIFF
--- a/zypper-migration
+++ b/zypper-migration
@@ -115,7 +115,8 @@ options = {
     :no_recommends => false,
     :replacefiles => false,
     :details => false,
-    :download => nil
+    :download => nil,
+    :no_snapshots=> false
 }
 
 STDOUT.sync = true
@@ -191,6 +192,10 @@ OptionParser.new do |opts|
 
   opts.on("--download-only", "Replace repositories and download the packages, do not install. WARNING: Upgrade with 'zypper dist-upgrade' as soon as possible.") do |d|
     options[:download] = "only" if d
+  end
+
+  opts.on("--no-snapshots", "Do not create snapshots.") do
+    options[:no_snapshots] = true
   end
 
 end.parse!
@@ -329,7 +334,7 @@ if options[:non_interactive] && migration_num == 0
 end
 
 
-while migration_num <= 0 || migration_num > migrations.length do 
+while migration_num <= 0 || migration_num > migrations.length do
   print "Available migrations:\n\n"
   migrations.each_with_index do |migration, index|
     printf "   %2d |", index + 1
@@ -344,7 +349,7 @@ while migration_num <= 0 || migration_num > migrations.length do
   end
   while migration_num <= 0 || migration_num > migrations.length do
     print "[num/q]: "
-    choice = gets.chomp 
+    choice = gets.chomp
     exit 0 if choice.eql?("q") || choice.eql?("Q")
     migration_num = choice.to_i
   end
@@ -352,9 +357,11 @@ end
 
 migration = migrations[migration_num - 1]
 
-cmd = "snapper create --type pre --cleanup-algorithm=number --print-number --userdata important=yes --description 'before online migration'"
-print "\nExecuting '#{cmd}'\n\n" unless options[:quiet]
-pre_snapshot_num = `#{cmd}`.to_i
+if !options[:no_snapshots]
+  cmd = "snapper create --type pre --cleanup-algorithm=number --print-number --userdata important=yes --description 'before online migration'"
+  print "\nExecuting '#{cmd}'\n\n" unless options[:quiet]
+  pre_snapshot_num = `#{cmd}`.to_i
+end
 
 ENV['DISABLE_SNAPPER_ZYPP_PLUGIN'] = '1'
 
@@ -474,7 +481,7 @@ if fs_inconsistent
   exit 2
 end
 
-if pre_snapshot_num > 0
+if !options[:no_snapshots] && pre_snapshot_num > 0
   cmd = "snapper create --type post --pre-number #{pre_snapshot_num} --cleanup-algorithm=number --print-number --userdata important=yes --description 'after online migration'"
   print "\nExecuting '#{cmd}'\n\n" unless options[:quiet]
   post_snapshot_num = `#{cmd}`.to_i
@@ -515,5 +522,3 @@ if !result
 end
 
 exit 1 unless result
-
-

--- a/zypper-migration
+++ b/zypper-migration
@@ -116,7 +116,8 @@ options = {
     :replacefiles => false,
     :details => false,
     :download => nil,
-    :no_snapshots=> false
+    :no_snapshots => false,
+    :root => nil
 }
 
 STDOUT.sync = true
@@ -198,6 +199,11 @@ OptionParser.new do |opts|
     options[:no_snapshots] = true
   end
 
+  opts.on("--root DIR", "Operate on a different root directory") do |r|
+    options[:root] = r
+    SUSE::Connect::System.filesystem_root = r
+  end
+
 end.parse!
 
 cmd = "zypper " +
@@ -212,6 +218,7 @@ if !system cmd
 end
 
 cmd = "zypper " +
+      (options[:root] ? "--root #{options[:root]} " : "") +
       (options[:non_interactive] ? "--non-interactive " : "") +
       (options[:verbose] ? "--verbose " : "") +
       (options[:quiet] ? "--quiet " : "") +
@@ -221,6 +228,7 @@ if !system cmd
   if $?.exitstatus >= 100
     # install pending updates and restart
     cmd = "zypper " +
+          (options[:root] ? "--root #{options[:root]} " : "") +
           (options[:non_interactive] ? "--non-interactive " : "") +
           (options[:verbose] ? "--verbose " : "") +
           (options[:quiet] ? "--quiet " : "") +
@@ -230,7 +238,10 @@ if !system cmd
 
     # stop infinite restarting
     # check that the patches were really installed
-    if ! system "zypper --non-interactive --quiet --no-refresh patch-check --updatestack-only > /dev/null"
+    cmd = "zypper " +
+      (options[:root] ? "--root #{options[:root]} " : "") +
+      "--non-interactive --quiet --no-refresh patch-check --updatestack-only > /dev/null"
+    if ! system cmd
       print "patch failed, exiting.\n"
       exit 1
     end
@@ -432,6 +443,7 @@ begin
   end
 
   cmd = "zypper " +
+        (options[:root] ? "--root #{options[:root]} " : "") +
         (base_product_version ? "--releasever #{base_product_version} " : "") +
         "ref -f"
   msg = "Executing '#{cmd}'"
@@ -442,6 +454,7 @@ begin
   raise "Interrupted." if interrupted
 
   cmd = "zypper " +
+        (options[:root] ? "--root #{options[:root]} " : "") +
         (base_product_version ? "--releasever #{base_product_version} " : "") +
         (options[:non_interactive] ? "--non-interactive " : "") +
         (options[:verbose] ? "--verbose " : "") +

--- a/zypper-migration.8
+++ b/zypper-migration.8
@@ -58,7 +58,14 @@ Set the download-install mode
 .TP
 .B --download-only
 Replace repositories and download the packages, do not install. WARNING: This leaves the system in inconsistent
-state with new repositories and old packages installed. Upgrade with 'zypper dist-upgrade' as soon as possible.
+state with new repositories and old packages installed. Upgrade with 'zypper
+dist-upgrade' as soon as possible.
+.TP
+.B --no-snapshots
+Don't create snapshots during migration
+.TP
+.B --root DIRECTORY
+Operate on a different root directory.
 .SH SEE ALSO
 zypper(8)
 .SH BUGS


### PR DESCRIPTION
creating snapshots at it's own. That's needed for e.g. transactional updates,
where the calling tools is taking care of snapshots and rollback in error
case.