### PR TITLE
Don't run final patch-check under --root

### DIFF
--- a/zypper-migration
+++ b/zypper-migration
@@ -271,7 +271,6 @@ if options[:selfupdate]
       # stop infinite restarting
       # check that the patches were really installed
       cmd = "zypper " +
-        (options[:root] ? "--root #{options[:root]} " : "") +
         "--non-interactive --quiet --no-refresh patch-check --updatestack-only > /dev/null"
       if ! system cmd
         print "patch failed, exiting.\n"


### PR DESCRIPTION
As the update stack can be located outside of system specified by
--root, all of the checks and patching should not pass --root to zypper.